### PR TITLE
[33기 손가영] ADD: Mypage 레이아웃 및 스타일링 UI 구현

### DIFF
--- a/public/data/catergoryList.json
+++ b/public/data/catergoryList.json
@@ -1,0 +1,31 @@
+{
+  "results": [
+    {
+      "id": 1,
+      "code": "01023451212",
+      "airline": "대한항공",
+      "kor_origin": "제주공항",
+      "kor_destination": "김포공항",
+      "logo_url": "https://flights.myrealtrip.com/air/wfw/imgs/mbl/logo/air/KE.png",
+      "date": "2022-06-20"
+    },
+    {
+      "id": 2,
+      "code": "01023451212",
+      "airline": "대한항공",
+      "kor_origin": "제주공항",
+      "kor_destination": "김포공항",
+      "logo_url": "https://flights.myrealtrip.com/air/wfw/imgs/mbl/logo/air/KE.png",
+      "date": "2022-06-20"
+    },
+    {
+      "id": 3,
+      "code": "01023451212",
+      "airline": "대한항공",
+      "kor_origin": "제주공항",
+      "kor_destination": "김포공항",
+      "logo_url": "https://flights.myrealtrip.com/air/wfw/imgs/mbl/logo/air/KE.png",
+      "date": "2022-06-20"
+    }
+  ]
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Mypage 레이아웃 및 스타일링 UI구현 

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 예약된 항공권 정보 컴포넌트화
- 예약페이지에서 넘어온 사용자의 예약 정보를 컴포넌트 화 하여 간략하게 사용자에게 보여지도록 구현
- 카드형식의 정보를 컴포넌트화 하여 map 함수를 적용
- 예약정보를 상수데이터로 만들어서 적용되는  map함수에 정보가 적용될 수 있도록함

2. Side bar (예정된 여행, 지난 여행, 취소된 여행) 정보를 각각 보여주도록 구현
- 예정된 여행이라는 카테고리에는 백엔드에서 가져온 정보를 받아와 보여질 수 있도록함
- 지난 여행이라는 카테고리는 상수데이터로 만들어 정보를 보여질 수 있도록함 해당 컴포넌트도 map함수 적용
- 취소된 여행의 카테고리는 취소된 여행이 없을 경우, 어떻게 보여지는 지를 사용자에게 전달 할 수 있도록 함
- 카테고리마다 다른 정보가 나도록 함 : useState를 숫자로(인덱스)로 정보를 저장하고 해당 컴포넌트가 보여질 자리에는 인덱스번호와 같을 때 각각 다른 컴포넌를 불러올 수 있도록 작성하였다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 카테고리를 눌렀을 때 다른 정보가 보여질 수 있도록 구현하는 과정에서 어떤 방식으로 컴포넌트를 가져와야 할 지 감이 오지 않았는데,   ex)` {mycategory === 1 && <ReservationCard />} `이런 방식으로 컴포넌트가 올자리가 부여된 인덱스 번호와 같을 때 페이지가 보여질 수 있도록 구현하며 해결하였다.

<br />

## :: 기타 질문 및 특이 사항
- 상세 페이지로 이동할 때 쿼리를 어떻게 저장하고 보내줘야할 지 궁금합니다...🙃 
