### PR TITLE
QueryParameter 활용한 로딩페이지 구현

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router-dom';
 const Nav = () => {
   const [category, setCategory] = useState(0);
   const location = useLocation();
-  const navigate = useNavigate();
+  const navigate = useNavigate;
   const goToLogin = () => {
     navigate('/login');
   };

--- a/src/pages/Loading/LoadingPage.js
+++ b/src/pages/Loading/LoadingPage.js
@@ -1,28 +1,44 @@
-import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 function LoadingPage() {
+  const navigate = useNavigate();
+  const urlDocument = new URL(document.location);
+  const params = urlDocument.searchParams;
+  const query = urlDocument.search;
+  const date = params.get('date');
+  const origin = params.get('origin');
+  const destination = params.get('destination');
+
+  const navigateFlight = () => {
+    navigate(`/flights${query}`);
+  };
+
+  setTimeout(() => navigateFlight(), 4000);
+
   return (
     <LoadingCover>
       <LoadingImage />
       <LoadingBackground />
       <LoadingContainer>
         <LoadingTitle>
-          <LoadingTitleText>김포에서 제주까지</LoadingTitleText>
           <LoadingTitleText>
-            <span>왕복 항공권을 찾고 있습니다.</span>
+            {origin}에서 {destination}까지
+          </LoadingTitleText>
+          <LoadingTitleText>
+            <span>편도 항공권을 찾고 있습니다.</span>
           </LoadingTitleText>
         </LoadingTitle>
         <LoadingData>
           <LoadingLocation>
-            <LoadingEngTitle>GMP</LoadingEngTitle>
-            <LoadingKorTitle>김포</LoadingKorTitle>
-            <LoadingTime>2022년 06월 21일</LoadingTime>
+            <LoadingEngTitle>{`${AIR_INITIAL[origin]}`}</LoadingEngTitle>
+            <LoadingKorTitle>{origin}</LoadingKorTitle>
+            <LoadingTime>{date}</LoadingTime>
           </LoadingLocation>
           <LoadingLocation>
-            <LoadingEngTitle>CJU</LoadingEngTitle>
-            <LoadingKorTitle>제주</LoadingKorTitle>
-            <LoadingTime>2022년 06월 21일</LoadingTime>
+            <LoadingEngTitle>{`${AIR_INITIAL[destination]}`}</LoadingEngTitle>
+            <LoadingKorTitle>{destination}</LoadingKorTitle>
+            <LoadingTime>{date}</LoadingTime>
           </LoadingLocation>
         </LoadingData>
         <LoadingContent>
@@ -36,6 +52,21 @@ function LoadingPage() {
     </LoadingCover>
   );
 }
+
+const AIR_INITIAL = {
+  제주: 'CJU',
+  김포: 'GMP',
+  부산: 'PUS',
+  청주: 'CJJ',
+  여수: 'RSU',
+  광주: 'KWJ',
+  대구: 'TAE',
+  양양: 'YNY',
+  군산: 'KUV',
+  울산: 'USN',
+  포항: 'KPO',
+  인천: 'ICN',
+};
 
 const LoadingCover = styled.div`
   ${({ theme }) => theme.flex.flexBox('column')};
@@ -54,6 +85,7 @@ const LoadingImage = styled.div`
   width: 100%;
   background: url('images/loadingImg.jpg') 0/ 110%;
   background-size: full;
+  background-repeat: no-repeat;
   @keyframes moveAirplane {
     0% {
       background-position: 0;


### PR DESCRIPTION
- setTimeout() 활용하여 로딩페이지 구현 (보여주기 위해서 하나의 페이지로 구현)
- queryParameter에서 사용자에게 정보를 띄워주는 기능 구현

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인페이지에서 전해주는 쿼리파라미터를 활용하여 사용자에게 정보를 띄워주는 로딩페이지를 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. setTimeout() 활용하여 로딩페이지 구현
- 원래 항공 리스트에서 로딩페이지를 컴포넌트로 활용하여 데이터가 불러오기 전에는 로딩페이지 컴포넌트를 띄워주고, 데이터 로딩이 완료되면 항공리스트를 컴포넌트를 띄워주는 기능을 구현해야 했으나 이렇게 하면 로딩페이지를 보는 시간이 짧아지므로 강제로 페이지를 3초간 띄우도록 구현하고자 하였음


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- setTimeout()에 대하여 공부하게 되었음
- Hook을 사용하는 방법에 대해서 더욱 깊게 이해할 수 있었음 (https://ko.reactjs.org/docs/hooks-rules.html#gatsby-focus-wrapper)

<br />

## :: 기타 질문 및 특이 사항

